### PR TITLE
in vfe_v4l2: fix the pixelformat returned by ioctl VIDIOC_G_FMT

### DIFF
--- a/drivers/media/video/sunxi-vfe/vfe.c
+++ b/drivers/media/video/sunxi-vfe/vfe.c
@@ -1814,7 +1814,7 @@ static int vidioc_g_fmt_vid_cap(struct file *file, void *priv,
 	f->fmt.pix.width        = dev->width;
 	f->fmt.pix.height       = dev->height;
 	f->fmt.pix.field        = dev->vb_vidq.field;
-	f->fmt.pix.pixelformat  = dev->fmt->bus_pix_code;
+	f->fmt.pix.pixelformat  = dev->fmt->fourcc;
 	//  f->fmt.pix.bytesperline = (f->fmt.pix.width * dev->fmt->depth) >> 3;
 	//  f->fmt.pix.sizeimage    = f->fmt.pix.height * f->fmt.pix.bytesperline;
 


### PR DESCRIPTION
Hi,
I am trying to use the V4L2 driver for a nanopi neo and the pixelformat returned is wrong.
You can find a fix that return the classical fourcc.
The buffersize are also wrong, but I guess it from height and width.
Best Regards,
Michel.