### PR TITLE
fs/file_table: split fget_light

### DIFF
--- a/fs/stat.c
+++ b/fs/stat.c
@@ -58,7 +58,7 @@ EXPORT_SYMBOL(vfs_getattr);
 int vfs_fstat(unsigned int fd, struct kstat *stat)
 {
 	int fput_needed;
-	struct file *f = fget_light(fd, &fput_needed);
+	struct file *f = __fget_light(fd, 0, &fput_needed);
 	int error = -EBADF;
 
 	if (f) {

--- a/include/linux/file.h
+++ b/include/linux/file.h
@@ -28,6 +28,7 @@ static inline void fput_light(struct file *file, int fput_needed)
 
 extern struct file *fget(unsigned int fd);
 extern struct file *fget_light(unsigned int fd, int *fput_needed);
+extern struct file *__fget_light(unsigned int fd, fmode_t mode, int *fput_needed);
 extern struct file *fget_raw(unsigned int fd);
 extern struct file *fget_raw_light(unsigned int fd, int *fput_needed);
 extern void set_close_on_exec(unsigned int fd, int flag);


### PR DESCRIPTION
due to systemd updated, sun8i kernel doesn't compact to new systemd.
after check systemd code, it return -EBADF in below code:

https://github.com/systemd/systemd/blob/master/src/basic/fs-util.c#L804-L815

fstat on path fds (open with O_PATH).

after check sun8i kernel code, in fstat path, fget_light rectly returns
NULL on path fds (file->f_mode & FMODE_PATH).

on mainline kernel, fget_light is wraper function of __fget_light.
on fstat path, it uses __fget_light, doesn't check FMODE_PATH.

so follow mainline kernel, change the behavior of sun8i kernel.

test case:

int main(int argc, char **argv)
{
    int fd;
    struct stat previous_stat;

    fd =  open("/", O_CLOEXEC|O_NOFOLLOW|O_PATH);
    if (fd < 0) {
        printf("%d, %s\n", __LINE__,  strerror(errno));
         return -errno;
    }

    if(fstat(fd, &previous_stat) < 0) {

        printf("%d, %s\n", __LINE__, strerror(errno));
        return -errno;
    }
}

expect no error.

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>